### PR TITLE
Fix : Redirect root route (/) to /listings

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,6 +63,10 @@ app.use("/listings",listingsRouter);
 app.use("/listings/:id/reviews",reviewsRouter);
 app.use("/", userRouter);
 
+app.get('/', (req, res) => {
+  res.redirect('/listing');
+});
+
 
 
 


### PR DESCRIPTION
This PR fixes the issue where visiting the root URL shows "Cannot GET /"

Added a redirect in app.js to send from "/" to "/listings'

closes #1