### PR TITLE
Fix: Redirect home route '/' to '/listings'

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,6 +63,11 @@ app.use("/listings",listingsRouter);
 app.use("/listings/:id/reviews",reviewsRouter);
 app.use("/", userRouter);
 
+// <----- TO REDIRECT TO '/LISTINGS' ROUTE WHEN A REQUEST IS SENT TO '/' (HOME ROUTE) AS HOMEPAGE OF WEBSITE IS AT '/LISTINGS' ----->
+app.get('/', (req, res) => {
+  res.redirect('/listings');
+});
+
 
 
 


### PR DESCRIPTION
### This PR fixes the home route. 
The original homepage was accessible at '/listings', but the root path '/ ' was not redirecting. This change adds a redirect from '/' to '/listings' to ensure correct landing behaviour.
Now the deployed link will also work, and no error will be generated when a request is sent at '/', i.e. the root path.