### PR TITLE
Fix: Align Edit and Delete buttons on listing show page (#49)

### DIFF
--- a/views/listings/show.ejs
+++ b/views/listings/show.ejs
@@ -16,12 +16,9 @@
                                 <%= listing.country %>
                 </p>
             </div>
-        </div>
-
-
-        <br />
+             <br />
         <div class="btns">
-            <a href="/listings/<%=listing._id %>/edit" class=" btn btn-dark  col-1 offset-2 edit-btn">
+            <a href="/listings/<%=listing._id %>/edit" class=" btn btn-dark  col-1 edit-btn">
                 Edit</a>
             <div class="col-1">
                 <form method="POST" action="/listings/<%=listing._id %>?_method=DELETE">
@@ -29,6 +26,10 @@
                 </form>
             </div>
         </div>
+        </div>
+
+
+       
 
 
 


### PR DESCRIPTION
## 🐛 Bug
The Edit and Delete buttons on the listing show page were misaligned due to inconsistent column offsets and lack of a container div.

### Before:
- Edit button had `offset-2` causing horizontal misalignment.
- Delete button sat awkwardly below or too far apart.
- No unified container wrapping the two.

<img width="1416" height="735" alt="Screenshot 2025-08-03 233956" src="https://github.com/user-attachments/assets/00b3e7b1-8c25-4b6d-ada0-4125c751cdeb" />

### After Fix 
 - Buttons are now  aligned and visually clean.
<img width="713" height="493" alt="image" src="https://github.com/user-attachments/assets/d9e89a68-35aa-45ec-90bc-96357a9ffc18" />


### 🔧 Fix
- Removed `offset-2` from Edit button.
- Wrapped both buttons in a `<div class="btns">` to maintain consistent layout and grouping.
- Ensured both use the same `col-1` class for equal width.
- Added `<br />` where needed to maintain vertical spacing.

### ✅ Expected Behavior
- Both buttons are now horizontally aligned.
- Layout remains responsive on smaller screens.


